### PR TITLE
Refactor obj loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 *.exe
 *.out
 *.app
+main
 
 # Others
 *.bat

--- a/src/build.cpp
+++ b/src/build.cpp
@@ -173,11 +173,7 @@ bool build_5(Scene& scene) {
     scene.set_camera(pinhole_ptr);
     scene.set_ibl(ibl_ptr);
 
-    ObjLoader obj_loader("./models/rungholt/rungholt.obj");
-    obj_loader.print_obj_data();
-    std::vector<Surface*> tmp_objects = obj_loader.convert_to_surfaces();
-
-    for (Object* obj_ptr : tmp_objects) {
+    for (Object* obj_ptr : ObjLoader().load_obj_file("./models/rungholt/rungholt.obj")) {
         scene.add_object(obj_ptr);
     };
 

--- a/src/obj_loader.cpp
+++ b/src/obj_loader.cpp
@@ -50,8 +50,8 @@ Surface* ObjLoader::face_group_to_surface(const FaceGroup& face_group) {
     } else {
         surface = new FlatSurface;
     }
-    convert<Vec>(vertices, face_group.triangles, surface->vertices, surface->triangles);
-    convert<std::pair<double, double>>(uv_coordinates, face_group.triangle_uv_coordinates, surface->uv_coordinates, surface->triangle_uv_coordinates);
+    convert<>(vertices, face_group.triangles, surface->vertices, surface->triangles);
+    convert<>(uv_coordinates, face_group.triangle_uv_coordinates, surface->uv_coordinates, surface->triangle_uv_coordinates);
 
     surface->material_ptr = new Material(*face_group.material_ptr);
 

--- a/src/obj_loader.cpp
+++ b/src/obj_loader.cpp
@@ -61,8 +61,8 @@ Surface* ObjLoader::face_group_to_surface(const FaceGroup& face_group) {
 std::vector<Surface*> ObjLoader::convert_to_surfaces() {
     printf("Converting to surface...\n");
     std::vector<Surface*> surface_objects;
-    for (size_t i = 0; i < groups.size(); i++) {
-        surface_objects.push_back(face_group_to_surface(groups[i]));
+    for (auto idx : groups) {
+        surface_objects.push_back(face_group_to_surface(idx));
     }
     return surface_objects;
 }
@@ -142,18 +142,19 @@ bool ObjLoader::load_obj_file(const std::string file_path) {
         return false;
     }
 
-    std::string line;
-    std::string keyword;
-    std::vector<std::string> sep_s;
     FaceGroup group;
     std::string prev_keyword;
     double val0, val1, val2;
+
     std::array<int, 4> v_idxs, vt_idxs, vn_idxs;
+
     while (!infile.eof()) {
+        std::string line;
         getline(infile, line);
         line = strip(line);
 
-        sep_s = split_reg(line, " +");
+        const std::vector<std::string> sep_s = split_reg(line, " +");
+        std::string keyword;
         if (line[0] == '#' || line == "") {
             keyword = "none";
         } else {

--- a/src/obj_loader.cpp
+++ b/src/obj_loader.cpp
@@ -13,7 +13,7 @@ FaceGroup::FaceGroup()
 
 ObjLoader::ObjLoader() : vertices(0), uv_coordinates(0), normals(0), groups(0), materials() {}
 ObjLoader::ObjLoader(std::string file_path)
-    : vertices(0), uv_coordinates(0), normals(0), groups(0), materials() {
+    : ObjLoader() {
     load_obj_file(file_path);
 }
 
@@ -109,29 +109,28 @@ bool ObjLoader::load_objmtl_file(const std::string file_path) {
 }
 
 std::tuple<int, int, int> to_vertex_numbers(std::string s) {
-    int v = 0, vt = 0, vn = 0;
     auto vec_str = split(s, '/');
 
     switch (vec_str.size()) {
         case 1: {
-            v = std::stoi(vec_str[0]);
-            break;
+            const int v = std::stoi(vec_str[0]);
+            return {v, 0, 0};
         }
         case 2: {
-            v = std::stoi(vec_str[0]);
-            vt = std::stoi(vec_str[1]);
-            break;
+            const int v = std::stoi(vec_str[0]);
+            const int vt = std::stoi(vec_str[1]);
+            return {v, vt, 0};
         }
         case 3: {
-            v = std::stoi(vec_str[0]);
-            vt = vec_str[1] != "" ? std::stoi(vec_str[1]) : 0;
-            vn = std::stoi(vec_str[2]);
-            break;
+            const int v = std::stoi(vec_str[0]);
+            const int vt = vec_str[1] != "" ? std::stoi(vec_str[1]) : 0;
+            const int vn = std::stoi(vec_str[2]);
+            return {v, vt, vn};
         }
         default:
             assert(!" 1 <= vec_str.size() <=3 expected.");
+            return {0, 0, 0};
     }
-    return {v, vt, vn};
 }
 
 void ObjLoader::push_indices(std::vector<int> &from_indices, 

--- a/src/obj_loader.cpp
+++ b/src/obj_loader.cpp
@@ -31,6 +31,7 @@ void ObjLoader::convert(const std::vector<T> &from_vertices,
             if (index_table.find(vi) == index_table.end()) {
                 to_vertices.push_back(from_vertices[vi]);
             }
+            index_table.emplace(vi, index_table.size());
         }
         to_indices.emplace_back(index_table[v1], index_table[v2], index_table[v3]);
     }
@@ -131,7 +132,7 @@ void ObjLoader::push_indices(std::vector<int> &from_indices,
                              std::vector<std::tuple<int, int, int>> &to_indices, 
                              const std::size_t offset) {
 
-    const auto no_index = vertices.size();
+    const auto no_index = from_indices.size();
     std::transform(from_indices.cbegin(), from_indices.cend(), from_indices.begin(), [&](auto v){ return to_index(v, offset); });
     for (std::size_t i = 0; i < no_index - 2; i++) {
         to_indices.emplace_back(from_indices[0], from_indices[i + 1], from_indices[i + 2]);

--- a/src/obj_loader.cpp
+++ b/src/obj_loader.cpp
@@ -44,12 +44,8 @@ void ObjLoader::convert(const std::vector<T> &from_vertices,
 
 
 Surface* ObjLoader::face_group_to_surface(const FaceGroup& face_group) {
-    Surface* surface;
-    if (face_group.smooth_flag) {
-        surface = new SmoothSurface;
-    } else {
-        surface = new FlatSurface;
-    }
+    Surface* const surface = face_group.smooth_flag ? (Surface *)(new SmoothSurface) : (Surface *)(new FlatSurface);
+
     convert<>(vertices, face_group.triangles, surface->vertices, surface->triangles);
     convert<>(uv_coordinates, face_group.triangle_uv_coordinates, surface->uv_coordinates, surface->triangle_uv_coordinates);
 

--- a/src/obj_loader.hpp
+++ b/src/obj_loader.hpp
@@ -38,6 +38,10 @@ class ObjLoader {
                  const std::vector<std::tuple<int, int, int>> &from_indices, 
                  std::vector<T> &to_vertices, 
                  std::vector<std::tuple<int, int, int>> &to_indices);
+    
+    void push_indices(std::vector<int> &from_indices, 
+                      std::vector<std::tuple<int, int, int>> &to_indices, 
+                      const std::size_t offset);
 
    public:
     ObjLoader();

--- a/src/obj_loader.hpp
+++ b/src/obj_loader.hpp
@@ -33,6 +33,12 @@ class ObjLoader {
 
     Surface *face_group_to_surface(const FaceGroup &face_group);
 
+    template<typename T>
+    void convert(const std::vector<T> &from_vertices, 
+                 const std::vector<std::tuple<int, int, int>> &from_indices, 
+                 std::vector<T> &to_vertices, 
+                 std::vector<std::tuple<int, int, int>> &to_indices);
+
    public:
     ObjLoader();
     ObjLoader(const std::string file_path);

--- a/src/obj_loader.hpp
+++ b/src/obj_loader.hpp
@@ -25,7 +25,7 @@ class ObjLoader {
     std::vector<std::pair<double, double>> uv_coordinates;
     std::vector<Vec> normals;
     std::vector<FaceGroup> groups;
-    std::unordered_map<std::string, Material> materials;
+    std::unordered_map<std::string, Material*> materials;
 
     inline int to_index(const int number, const int n_vertices) {
         return number < 0 ? n_vertices + number : number - 1;
@@ -43,16 +43,15 @@ class ObjLoader {
                       std::vector<std::tuple<int, int, int>> &to_indices, 
                       const std::size_t offset);
 
+    void print_obj_data();
+    std::vector<Surface *> convert_to_surfaces();
+
    public:
     ObjLoader();
-    ObjLoader(const std::string file_path);
 
     void all_smooth_flag(const bool smooth_flag);
     bool load_objmtl_file(const std::string file_path);
-    bool load_obj_file(const std::string file_path);
-    std::unordered_map<std::string, Material> get_materials();
-    std::vector<Surface *> convert_to_surfaces();
-    void print_obj_data();
+    std::vector<Surface *> load_obj_file(const std::string file_path);
 };
 
 #endif


### PR DESCRIPTION
obj_loader.cpp/hpp 周辺のリファクタリングを行いました。

* 冗長な処理の切り出しと共通化(convert, push_indices)
* Material を値で持つ → ポインタで持つ
* load_obj_file の結果が直接 std::vector<Surface *> で返る
* その他一時変数の除去やスコープを短くする等

確認していただいて、よろしければ develop ブランチへ pull してみてください。